### PR TITLE
Pzc register login improvements

### DIFF
--- a/src/auth/Login.js
+++ b/src/auth/Login.js
@@ -70,9 +70,9 @@ export default class Login extends Component {
             <form className="form-signin" onSubmit={this.handleLogin}>
                 <h1 className="h3 mb-3 font-weight-normal">Please sign in</h1>
                 <label htmlFor="inputEmail" className="sr-only">Email address</label>
-                <input onChange={this.handleFieldChange} defaultValue={this.props.newEmail} type="email" id="email" className="form-control" required="" autoFocus="" />
+                <input onChange={this.handleFieldChange} defaultValue={this.props.newEmail} placeholder="Email address" type="email" id="email" className="form-control" required="" autoFocus="" />
                 <label htmlFor="inputPassword" className="sr-only">Password</label>
-                <input onChange={this.handleFieldChange} type="password" id="password" className="form-control" defaultValue={this.props.newPassword} required="" />
+                <input onChange={this.handleFieldChange} type="password" id="password" className="form-control" defaultValue={this.props.newPassword} placeholder="Password" required="" />
                 <div className="checkbox mb-3">
                     <input type="checkbox" value="remember-me" /> Remember me
                 </div>

--- a/src/auth/Login.js
+++ b/src/auth/Login.js
@@ -1,87 +1,127 @@
-import React, { Component } from "react"
-import App from "../App"
-import "./login.css"
-
+import React, { Component } from "react";
+import App from "../App";
+import "./login.css";
 
 export default class Login extends Component {
-
-    // Set initial state
-    state = {
+  constructor(props) {
+    super(props)
+    if (this.props.newEmail === null) {
+      this.state = {
         email: "",
         password: ""
+      }
+    } else {
+      this.state = {
+        email: this.props.newEmail,
+        password: this.props.newPassword
+      }
     }
+  }
 
+      
 
-    // Update state whenever an input field is edited
-    handleFieldChange = function (evt) {
-        const stateToChange = {}
-        stateToChange[evt.target.id] = evt.target.value
-        this.setState(stateToChange)
-    }.bind(this)
+  // Update state whenever an input field is edited
+  handleFieldChange = function(evt) {
+    const stateToChange = {};
+    stateToChange[evt.target.id] = evt.target.value;
+    this.setState(stateToChange);
+  }.bind(this);
 
-    // Handle for login submit
-    handleLogin = function (e) {
-        e.preventDefault()
+  // Handle for login submit
+  handleLogin = function(e) {
+    e.preventDefault();
 
-        // Determine if a user already exists in API
-        fetch(`http://localhost:5001/users?email=${this.state.email}&password=${this.state.password}`)
-            .then(r => r.json())
-            .then(user => {
-                // User exists. Set local storage, and show home view
-                if (user.length) {
-                    this.props.setActiveUser(user[0].id)
-                    this.props.showView("home")
+    // Determine if a user already exists in API
+    fetch(
+      `http://localhost:5001/users?email=${this.state.email}&password=${
+        this.state.password
+      }`
+    )
+      .then(r => r.json())
+      .then(user => {
+        // User exists. Set local storage, and show home view
+        if (user.length) {
+          this.props.setActiveUser(user[0].id);
+          this.props.showView("home");
 
-                // User doesn't exist
-                } else {
-                    alert("Email and Password Do Not Match Our Records.")
-                    // // Create user in API
-                    // fetch("http://localhost:5001/users", {
-                    //     method: "POST",
-                    //     headers: {
-                    //         "Content-Type": "application/json"
-                    //     },
-                    //     body: JSON.stringify({email: this.state.email, password: this.state.password})
-                    // })
+          // User doesn't exist
+        } else {
+          alert("Email and Password Do Not Match Our Records.");
+          // // Create user in API
+          // fetch("http://localhost:5001/users", {
+          //     method: "POST",
+          //     headers: {
+          //         "Content-Type": "application/json"
+          //     },
+          //     body: JSON.stringify({email: this.state.email, password: this.state.password})
+          // })
 
-                    // // Set local storage with newly created user's id and show home view
-                    // .then(newUser => {
-                    //     this.props.setActiveUser(newUser.id)
-                    //     this.props.showView("home")
-                    // })
-                }
+          // // Set local storage with newly created user's id and show home view
+          // .then(newUser => {
+          //     this.props.setActiveUser(newUser.id)
+          //     this.props.showView("home")
+          // })
+        }
+      });
+  }.bind(this);
 
-            })
-    }.bind(this)
+  registerButtonClick = () => {
+    this.props.showView("register");
+  };
 
-    registerButtonClick = () => {
-      this.props.showView("register")
-    }
-
-    /*
+  /*
         TODO:
             - Add first name field
             - Add last name field
             - Add password verification field
     */
-    render() {
-        return (
-          <div className="formDiv">
-            <form className="form-signin" onSubmit={this.handleLogin}>
-                <h1 className="h3 mb-3 font-weight-normal">Please sign in</h1>
-                <label htmlFor="inputEmail" className="sr-only">Email address</label>
-                <input onChange={this.handleFieldChange} defaultValue={this.props.newEmail} placeholder="Email address" type="email" id="email" className="form-control" required="" autoFocus="" />
-                <label htmlFor="inputPassword" className="sr-only">Password</label>
-                <input onChange={this.handleFieldChange} type="password" id="password" className="form-control" defaultValue={this.props.newPassword} placeholder="Password" required="" />
-                <div className="checkbox mb-3">
-                    <input type="checkbox" value="remember-me" /> Remember me
-                </div>
-                <button className="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
-                
-                <button id="login__register" className="btn btn-lg btn-info btn-block" onClick={this.registerButtonClick}>Register</button>
-                <p className="mt-5 mb-3 text-muted">© 2017-2018</p>
-            </form>
-            </div>
-        )
-    }
+  render() {
+    return (
+      <div className="formDiv">
+        <form className="form-signin" onSubmit={this.handleLogin}>
+          <h1 className="h3 mb-3 font-weight-normal">Please sign in</h1>
+          <label htmlFor="inputEmail" className="sr-only">
+            Email address
+          </label>
+          <input
+            onChange={this.handleFieldChange}
+            defaultValue={this.props.newEmail}
+            placeholder="Email address"
+            type="email"
+            id="email"
+            className="form-control"
+            required=""
+            autoFocus=""
+          />
+          <label htmlFor="inputPassword" className="sr-only">
+            Password
+          </label>
+          <input
+            onChange={this.handleFieldChange}
+            type="password"
+            id="password"
+            className="form-control"
+            defaultValue={this.props.newPassword}
+            placeholder="Password"
+            required=""
+          />
+          <div className="checkbox mb-3">
+            <input type="checkbox" value="remember-me" /> Remember me
+          </div>
+          <button className="btn btn-lg btn-primary btn-block" type="submit">
+            Sign in
+          </button>
+
+          <button
+            id="login__register"
+            className="btn btn-lg btn-info btn-block"
+            onClick={this.registerButtonClick}
+          >
+            Register
+          </button>
+          <p className="mt-5 mb-3 text-muted">© 2017-2018</p>
+        </form>
+      </div>
+    );
+  }
 }

--- a/src/auth/Register.js
+++ b/src/auth/Register.js
@@ -57,7 +57,7 @@ class Register extends Component {
     const submittedImageUrl = this.state.image;
     const submittedLocation = this.state.location;
 
-    fetch(`http://localhost:8088/users?email=${submittedEmail}`)
+    fetch(`http://localhost:5001/users?email=${submittedEmail}`)
       // Must be explicit on how to parse the response
       .then(r => r.json())
 


### PR DESCRIPTION
Improvements on Create a user: 

1. login page shows email and password as default text when coming to login from anywhere other than register apge
2. email/password are pushed to login page after registering and added to state, so login shoud be possible 


to test:
```
git fetch --all
git checkout pzc-register-login-improvements
```

1. ON login, see that in username/password fields there is text indicating which info goes where
2. Click register
3. Fill out form with unique information
4. Submit
5. See user was added to database
6. See new username/password is added to state and added to fields on login

This PR touches: 

Login.js
Register.js
App.js