### PR TITLE
register and ogin cleanup

### DIFF
--- a/src/auth/Login.js
+++ b/src/auth/Login.js
@@ -105,9 +105,6 @@ export default class Login extends Component {
             placeholder="Password"
             required=""
           />
-          <div className="checkbox mb-3">
-            <input type="checkbox" value="remember-me" /> Remember me
-          </div>
           <button className="btn btn-lg btn-primary btn-block" type="submit">
             Sign in
           </button>

--- a/src/auth/Register.js
+++ b/src/auth/Register.js
@@ -106,56 +106,44 @@ class Register extends Component {
         {/* <h1>Sign-up to use our app below!</h1> */}
         <form onSubmit={this.handleSubmit} className="form-login">
         <h1 className="h3 mb-3 font-weight-normal">Register to use Yak:</h1>
-          <label>
-            First Name:
+            
             <input className="form-control"
+            placeholder="First Name"
               type="text"
               value={this.state.firstname}
               onChange={this.firstnameChange}
             />
-          </label>
-          <label>
-            Last Name:
             <input className="form-control"
               type="text"
+              placeholder="Last name"
               value={this.state.lastname}
               onChange={this.lastnameChange}
             />
-          </label>
-          <label>
-            Email:
             <input className="form-control"
+              placeholder="Email"
               type="text"
               value={this.state.email}
               onChange={this.emailChange}
             />
-          </label>
-          <label>
-            Password:
             <input className="form-control"
+            placeholder="Password"
               type="password"
               value={this.state.password}
               onChange={this.passwordChange}
             />
-          </label>
-          <label>
-            Image URL:
             <input className="form-control"
               type="text"
+              placeholder="Image URL"
               value={this.state.image}
               onChange={this.imageChange}
             />
-          </label>
-          <label>
-            Location:
             <select value={this.state.location} onChange={this.locationChange} className="form-control">
-              <option defaultValue="">Pick one</option>
+              <option defaultValue="">Location:</option>
               <option value="Nashville">Nashville</option>
               <option value="Memphis">Memphis</option>
               <option value="Knoxville">Knoxville</option>
               <option value="Chattanooga">Chattanooga</option>
             </select>
-          </label>
           <input type="submit" value="Submit" className="btn btn-lg btn-info btn-block"/>
           <div id="emailExistsAlert" className="emailexists">
           <p>That email address already exists. Click here to log in.</p>

--- a/src/auth/login.css
+++ b/src/auth/login.css
@@ -6,5 +6,5 @@
 }
 
 .form-control {
-    margin: 5px 0;
+    margin: 15px 0;
 }

--- a/src/auth/register.css
+++ b/src/auth/register.css
@@ -6,18 +6,17 @@
 }
 
 .form-control {
-  margin: 5px 0;
+  margin: 15px 0;
+  width: 100%
 }
 h1 {
   color: red;
 }
 
-label {
-
-}
-
 input, select {
   display: block;
+  width: 100%;
+  margin-top: 10px
 }
 
 #emailExistsAlert.emailexists {


### PR DESCRIPTION
Couple of tweaks:

1. Register fields are as wide as the button
2. Field labels are now placeholder text instead of labels
3. ON login page, remember me checkbox is gone (this wasn't hooked up to anything)

To test: 

```
git fetch --all
git checkout pzc-register-tweaks
```
1. On login, see that the remember me button is gone
2. See 15px spacing between fields on login and register
3. On register, see that placeholder text is in fields indicating what should go in each field, and lables are gone

Areas of impact: 

Login.js
Register.js